### PR TITLE
Add support for mastery scroll counts

### DIFF
--- a/src/Extractor/AccountDumpClient.cs
+++ b/src/Extractor/AccountDumpClient.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using SharedModel.Battle.Effects;
 using SharedModel.Meta.Heroes;
+using SharedModel.Meta.Masteries;
 
 #pragma warning disable 108 // Disable "CS0108 '{derivedDto}.ToJson()' hides inherited member '{dtoBase}.ToJson()'. Use the new keyword if hiding was intended."
 #pragma warning disable 114 // Disable "CS0114 '{derivedDto}.RaisePropertyChanged(String)' hides inherited member 'dtoBase.RaisePropertyChanged(String)'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword."
@@ -191,11 +192,27 @@ namespace RaidExtractor.Core
         [Newtonsoft.Json.JsonProperty("speed", Required = Newtonsoft.Json.Required.Always)]
         public float Speed { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("masteries", Required = Newtonsoft.Json.Required.Always)]
-        public List<int> Masteries { get; set; }
+        [Newtonsoft.Json.JsonProperty("masteryData", Required = Newtonsoft.Json.Required.Always)]
+        public MasteryData MasteryData { get; set; }
 
         [Newtonsoft.Json.JsonProperty("skills", Required = Newtonsoft.Json.Required.Always)]
         public List<Skill> Skills { get; set; }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.24.0 (Newtonsoft.Json v11.0.0.0)")]
+    public partial class MasteryData
+    {
+	    [Newtonsoft.Json.JsonProperty("currentAmount", Required = Newtonsoft.Json.Required.AllowNull)]
+	    public Dictionary<MasteryPointType, int> CurrentAmount { get; set; }
+
+	    [Newtonsoft.Json.JsonProperty("totalAmount", Required = Newtonsoft.Json.Required.AllowNull)]
+	    public Dictionary<MasteryPointType, int> TotalAmount { get; set; }
+
+	    [Newtonsoft.Json.JsonProperty("masteries", Required = Newtonsoft.Json.Required.Always)]
+	    public List<int> Masteries { get; set; }
+
+	    [Newtonsoft.Json.JsonProperty("resetCount", Required = Newtonsoft.Json.Required.Always)]
+	    public int ResetCount { get; set; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.24.0 (Newtonsoft.Json v11.0.0.0)")]

--- a/src/Extractor/Extractor.cs
+++ b/src/Extractor/Extractor.cs
@@ -46,6 +46,17 @@ namespace Raid.Extractor
             Level = skill.Level
         };
 
+        public static MasteryData Dump(this SharedModel.Meta.Masteries.HeroMasteryData masteryData)
+        {
+	        return new()
+	        {
+		        Masteries = masteryData?.Masteries.ToList() ?? new List<int>(),
+		        CurrentAmount = masteryData?.CurrentAmount?.ToDictionary(pair => pair.Key, pair => pair.Value),
+		        TotalAmount = masteryData?.TotalAmount?.ToDictionary(pair => pair.Key, pair => pair.Value),
+		        ResetCount = masteryData?.ResetCount ?? 0
+	        };
+        }
+
         public static ICollection<Hero> Dump(
             this IEnumerable<SharedModel.Meta.Heroes.Hero> heroes,
             IReadOnlyDictionary<int, SharedModel.Meta.Artifacts.HeroArtifactData> artifactData,
@@ -66,7 +77,7 @@ namespace Raid.Extractor
                 InStorage = hero.InStorage,
                 Marker = hero.Marker.ToString(),
                 // extras
-                Masteries = hero.MasteryData?.Masteries.ToList() ?? new(),
+                MasteryData = hero.MasteryData.Dump(),
                 Artifacts = artifactData.TryGetValue(hero.Id, out SharedModel.Meta.Artifacts.HeroArtifactData data) ? data?.ArtifactIdByKind.Values.ToList() ?? new() : new(),
                 Skills = hero.Skills?.Select(Extensions.Dump).ToList() ?? new(),
                 // type fields

--- a/src/Extractor/Program.cs
+++ b/src/Extractor/Program.cs
@@ -32,6 +32,7 @@ namespace Raid.Extractor
         public static JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
         {
             Formatting = Formatting.Indented,
+            NullValueHandling = NullValueHandling.Ignore,
             ContractResolver = new DefaultContractResolver
             {
                 NamingStrategy = new CamelCaseNamingStrategy


### PR DESCRIPTION
This PR adds support for mastery scrolls.
Resolves https://github.com/LukeCroteau/RaidExtractor/issues/77

Obviously, it's just a test how an implementation with the toolkit sdk *could* be. I am not happy with the implementation, especially handling the null values. This is also a breaking change and does not support backwards compatibility. All around, you should probably not merge this!

Reminder for myself: This still needs a fileVersion prop in the output json.

N.B. awesome job on the SDK and the work around it, this is huge!