### PR TITLE
Launching service on-demand from rtk:// protocol doesn't load configuration

### DIFF
--- a/SDK/Service/Actions/RunAction.cs
+++ b/SDK/Service/Actions/RunAction.cs
@@ -29,10 +29,11 @@ namespace Raid.Service
             {
                 options.NoUI = false;
             }
-            if (Environment.GetEnvironmentVariable("RTK_DEBUG") != "true")
+            string exeDir = Path.GetDirectoryName(AppConfiguration.ExecutablePath);
+            string parentDirName = Path.GetFileName(exeDir);
+            if (Environment.GetEnvironmentVariable("RTK_DEBUG") != "true" && parentDirName != "win-x64")
             {
                 string expectedInstallPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "RaidToolkit");
-                string exeDir = Path.GetDirectoryName(AppConfiguration.ExecutablePath);
                 string exeName = Path.GetFileName(AppConfiguration.ExecutablePath);
                 string expectedExePath = Path.Join(expectedInstallPath, exeName);
                 string expectedConfigPath = Path.Join(expectedInstallPath, "appsettings.json");

--- a/SDK/Service/Host.cs
+++ b/SDK/Service/Host.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -16,6 +17,7 @@ namespace Raid.Service
 
         private static IHostBuilder CreateHostBuilder() => WebSocketHostBuilder.Create()
             .UseWebSocketMessageHandler(ModelService.HandleMessage)
+            .ConfigureAppConfiguration(config => config.AddJsonFile(Path.Join(AppConfiguration.ExecutableDirectory, "appsettings.json"), false))
             .ConfigureServices((ctx, services) => services
                 .Configure<AppSettings>(opts => ctx.Configuration.GetSection("app").Bind(opts))
                 .AddLogging(builder =>


### PR DESCRIPTION
Stupid .net logic of loading from CWD instead of execution directory....