### PR TITLE
Add DPI awareness for Windows forms

### DIFF
--- a/SDK/Service/Services/MainService.cs
+++ b/SDK/Service/Services/MainService.cs
@@ -97,6 +97,7 @@ namespace Raid.Service
             Console.CancelKeyPress += (sender, e) => Application.Exit();
             TaskExtensions.RunAfter(1, UpdateAccounts);
 
+            Application.SetHighDpiMode(HighDpiMode.SystemAware);
             Application.Run(ServiceProvider.GetRequiredService<UI.MainWindow>());
         }
 


### PR DESCRIPTION
This PR adds high DPI support for Windows forms.

Turns this:
![image](https://user-images.githubusercontent.com/219458/143611646-515a3991-c084-42c8-909c-90dd628bc0a0.png)
and
![image](https://user-images.githubusercontent.com/219458/143611650-b8926063-5e29-41ae-8d70-c164c00a9a99.png)

into

![image](https://user-images.githubusercontent.com/219458/143611662-12f78acd-d255-47fa-b421-069bbb3af412.png)
and
![image](https://user-images.githubusercontent.com/219458/143611684-c713e61e-c749-4d63-96b2-5c27d3f4d35d.png)
