### PR TITLE
EffectType extending.

### DIFF
--- a/SDK/DataModel/StaticData/SkillType.cs
+++ b/SDK/DataModel/StaticData/SkillType.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 
@@ -73,6 +74,713 @@ namespace Raid.DataModel
         }
     }
 
+    public enum EffectKindId
+    {
+        Revive = 0,
+        Heal = 1000, // 0x000003E8
+        StartOfStatusBuff = 2000, // 0x000007D0
+        BlockDamage = 2001, // 0x000007D1
+        BlockDebuff = 2002, // 0x000007D2
+        ContinuousHeal = 2003, // 0x000007D3
+        Shield = 2004, // 0x000007D4
+        StatusCounterattack = 2005, // 0x000007D5
+        ReviveOnDeath = 2006, // 0x000007D6
+        ShareDamage = 2007, // 0x000007D7
+        Unkillable = 2008, // 0x000007D8
+        DamageCounter = 2009, // 0x000007D9
+        ReflectDamage = 2010, // 0x000007DA
+        HitCounterShield = 2012, // 0x000007DC
+        Invisible = 2013, // 0x000007DD
+        ReduceDamageTaken = 2014, // 0x000007DE
+        CrabShell = 2015, // 0x000007DF
+        CritShield = 2016, // 0x000007E0
+        SkyWrath = 2017, // 0x000007E1
+        Enrage = 2018, // 0x000007E2
+        VoidAbyss = 2019, // 0x000007E3
+        StatusIncreaseAttack = 2101, // 0x00000835
+        StatusIncreaseDefence = 2102, // 0x00000836
+        StatusIncreaseSpeed = 2103, // 0x00000837
+        StatusIncreaseCriticalChance = 2104, // 0x00000838
+        StatusChangeDamageMultiplier = 2105, // 0x00000839
+        StatusIncreaseAccuracy = 2106, // 0x0000083A
+        StatusIncreaseCriticalDamage = 2107, // 0x0000083B
+        EndOfStatusBuff = 2999, // 0x00000BB7
+        StartOfStatusDebuff = 3000, // 0x00000BB8
+        Freeze = 3001, // 0x00000BB9
+        Provoke = 3002, // 0x00000BBA
+        Sleep = 3003, // 0x00000BBB
+        Stun = 3004, // 0x00000BBC
+        BlockHeal = 3005, // 0x00000BBD
+        BlockActiveSkills = 3006, // 0x00000BBE
+        ContinuousDamage = 3007, // 0x00000BBF
+        BlockBuffs = 3008, // 0x00000BC0
+        TimeBomb = 3009, // 0x00000BC1
+        IncreaseDamageTaken = 3010, // 0x00000BC2
+        BlockRevive = 3011, // 0x00000BC3
+        Mark = 3012, // 0x00000BC4
+        LifeDrainOnDamage = 3013, // 0x00000BC5
+        AoEContinuousDamage = 3014, // 0x00000BC6
+        Fear = 3015, // 0x00000BC7
+        IncreasePoisoning = 3016, // 0x00000BC8
+        BlockPassiveSkills = 3017, // 0x00000BC9
+        StatusReduceAttack = 3101, // 0x00000C1D
+        StatusReduceDefence = 3102, // 0x00000C1E
+        StatusReduceSpeed = 3103, // 0x00000C1F
+        StatusReduceCriticalChance = 3104, // 0x00000C20
+        StatusReduceAccuracy = 3105, // 0x00000C21
+        StatusReduceCriticalDamage = 3106, // 0x00000C22
+        EndOfStatusDebuff = 3999, // 0x00000F9F
+        ApplyBuff = 4000, // 0x00000FA0
+        IncreaseStamina = 4001, // 0x00000FA1
+        RemoveDebuff = 4003, // 0x00000FA3
+        ActivateSkill = 4004, // 0x00000FA4
+        ShowHiddenSkill = 4005, // 0x00000FA5
+        TeamAttack = 4006, // 0x00000FA6
+        ExtraTurn = 4007, // 0x00000FA7
+        LifeShare = 4008, // 0x00000FA8
+        ReduceCooldown = 4009, // 0x00000FA9
+        ReduceDebuffLifetime = 4010, // 0x00000FAA
+        IncreaseBuffLifetime = 4011, // 0x00000FAB
+        PassiveCounterattack = 4012, // 0x00000FAC
+        PassiveChangeStats = 4013, // 0x00000FAD
+        PassiveBlockDebuff = 4014, // 0x00000FAE
+        PassiveBonus = 4015, // 0x00000FAF
+        MultiplyBuff = 4016, // 0x00000FB0
+        PassiveReflectDamage = 4017, // 0x00000FB1
+        PassiveShareDamage = 4018, // 0x00000FB2
+        IncreaseShield = 4020, // 0x00000FB4
+        ReturnDebuffs = 4021, // 0x00000FB5
+        TransferDebuff = 4022, // 0x00000FB6
+        EndOfInstantBuff = 4999, // 0x00001387
+        ApplyDebuff = 5000, // 0x00001388
+        ReduceStamina = 5001, // 0x00001389
+        StealBuff = 5002, // 0x0000138A
+        RemoveBuff = 5003, // 0x0000138B
+        IncreaseCooldown = 5004, // 0x0000138C
+        ReduceBuffLifetime = 5005, // 0x0000138D
+        PassiveDebuffLifetime = 5006, // 0x0000138E
+        SwapHealth = 5007, // 0x0000138F
+        IncreaseDebuffLifetime = 5008, // 0x00001390
+        DestroyHp = 5009, // 0x00001391
+        Detonate = 5010, // 0x00001392
+        MultiplyDebuff = 5011, // 0x00001393
+        ReduceShield = 5012, // 0x00001394
+        EndOfInstantDebuff = 5999, // 0x0000176F
+        Damage = 6000, // 0x00001770
+        HitTypeModifier = 7000, // 0x00001B58
+        ChangeDefenceModifier = 7001, // 0x00001B59
+        ChangeEffectAccuracy = 7002, // 0x00001B5A
+        MultiplyEffectChance = 7003, // 0x00001B5B
+        ChangeDamageMultiplier = 7004, // 0x00001B5C
+        IgnoreProtectionEffects = 7005, // 0x00001B5D
+        ChangeCalculatedDamage = 7006, // 0x00001B5E
+        ChangeEffectRepeatCount = 7007, // 0x00001B5F
+        ChangeDestroyHpAmount = 7008, // 0x00001B60
+        ChangeHealMultiplier = 7009, // 0x00001B61
+        ChangeStaminaModifier = 7010, // 0x00001B62
+        Summon = 8000, // 0x00001F40
+        CopyHero = 8001, // 0x00001F41
+        ChangeEffectTarget = 9000, // 0x00002328
+        CancelEffect = 9001, // 0x00002329
+        ForceStatusEffectTick = 9002, // 0x0000232A
+        ChangeSkyWrathCounter = 9005, // 0x0000232D
+        UpdateCombo = 9006, // 0x0000232E
+        SetVoidAbyssCounter = 9007, // 0x0000232F
+        StatusBanish = 9010, // 0x00002332
+        Banish = 9011, // 0x00002333
+        EffectDurationModifier = 10000, // 0x00002710
+        CheckTargetForCondition = 11000, // 0x00002AF8
+        EffectContainer = 11001, // 0x00002AF9
+    }
+    public enum EffectTargetType
+    {
+        Target = 0,
+        Producer = 1,
+        RelationTarget = 2,
+        RelationProducer = 3,
+        Owner = 4,
+        RandomAlly = 5,
+        RandomEnemy = 6,
+        AllAllies = 7,
+        AllEnemies = 8,
+        AllDeadAllies = 9,
+        RandomDeadAlly = 13, // 0x0000000D
+        RandomDeadEnemy = 14, // 0x0000000E
+        MostInjuredAlly = 19, // 0x00000013
+        MostInjuredEnemy = 20, // 0x00000014
+        Boss = 22, // 0x00000016
+        RandomRevivableAlly = 25, // 0x00000019
+        OwnerAllies = 26, // 0x0000001A
+        AllHeroes = 29, // 0x0000001D
+        ActiveHero = 31, // 0x0000001F
+        AllyWithLowestMaxHp = 32, // 0x00000020
+        HeroCausedRelationUnapply = 33, // 0x00000021
+        HeroThatKilledProducer = 34, // 0x00000022
+        RelationTargetDuplicates = 35, // 0x00000023
+        AllyWithLowestStamina = 36, // 0x00000024
+        AllyWithHighestStamina = 37, // 0x00000025
+        EnemyWithLowestStamina = 38, // 0x00000026
+        EnemyWithHighestStamina = 39, // 0x00000027
+        RelationProducerOrTeamAttackInitiator = 40, // 0x00000028
+    }
+
+    public enum StatusEffectTypeId
+    {
+        Stun = 10, // 0x0000000A
+        Freeze = 20, // 0x00000014
+        Sleep = 30, // 0x0000001E
+        Provoke = 40, // 0x00000028
+        Counterattack = 50, // 0x00000032
+        BlockDamage = 60, // 0x0000003C
+        BlockHeal100p = 70, // 0x00000046
+        BlockHeal50p = 71, // 0x00000047
+        ContinuousDamage5p = 80, // 0x00000050
+        ContinuousDamage025p = 81, // 0x00000051
+        ContinuousHeal075p = 90, // 0x0000005A
+        ContinuousHeal15p = 91, // 0x0000005B
+        BlockDebuff = 100, // 0x00000064
+        BlockBuffs = 110, // 0x0000006E
+        IncreaseAttack25 = 120, // 0x00000078
+        IncreaseAttack50 = 121, // 0x00000079
+        DecreaseAttack25 = 130, // 0x00000082
+        DecreaseAttack50 = 131, // 0x00000083
+        IncreaseDefence30 = 140, // 0x0000008C
+        IncreaseDefence60 = 141, // 0x0000008D
+        DecreaseDefence30 = 150, // 0x00000096
+        DecreaseDefence60 = 151, // 0x00000097
+        IncreaseSpeed15 = 160, // 0x000000A0
+        IncreaseSpeed30 = 161, // 0x000000A1
+        DecreaseSpeed15 = 170, // 0x000000AA
+        DecreaseSpeed30 = 171, // 0x000000AB
+        IncreaseAccuracy25 = 220, // 0x000000DC
+        IncreaseAccuracy50 = 221, // 0x000000DD
+        DecreaseAccuracy25 = 230, // 0x000000E6
+        DecreaseAccuracy50 = 231, // 0x000000E7
+        IncreaseCriticalChance15 = 240, // 0x000000F0
+        IncreaseCriticalChance30 = 241, // 0x000000F1
+        DecreaseCriticalChance15 = 250, // 0x000000FA
+        DecreaseCriticalChance30 = 251, // 0x000000FB
+        IncreaseCriticalDamage15 = 260, // 0x00000104
+        IncreaseCriticalDamage30 = 261, // 0x00000105
+        DecreaseCriticalDamage15p = 270, // 0x0000010E
+        DecreaseCriticalDamage25p = 271, // 0x0000010F
+        Shield = 280, // 0x00000118
+        BlockActiveSkills = 290, // 0x00000122
+        ReviveOnDeath = 300, // 0x0000012C
+        ShareDamage50 = 310, // 0x00000136
+        ShareDamage25 = 311, // 0x00000137
+        Unkillable = 320, // 0x00000140
+        TimeBomb = 330, // 0x0000014A
+        DamageCounter = 340, // 0x00000154
+        IncreaseDamageTaken25 = 350, // 0x0000015E
+        IncreaseDamageTaken15 = 351, // 0x0000015F
+        BlockRevive = 360, // 0x00000168
+        ArtifactSet_Shield = 370, // 0x00000172
+        ReflectDamage15 = 410, // 0x0000019A
+        ReflectDamage30 = 411, // 0x0000019B
+        MinotaurIncreaseDamage = 420, // 0x000001A4
+        MinotaurIncreaseDamageTaken = 430, // 0x000001AE
+        Mark = 440, // 0x000001B8
+        HitCounterShield = 450, // 0x000001C2
+        LifeDrainOnDamage10p = 460, // 0x000001CC
+        Burn = 470, // 0x000001D6
+        Invisible1 = 480, // 0x000001E0
+        Invisible2 = 481, // 0x000001E1
+        Fear1 = 490, // 0x000001EA
+        Fear2 = 491, // 0x000001EB
+        IncreasePoisoning25 = 500, // 0x000001F4
+        IncreasePoisoning50 = 501, // 0x000001F5
+        ReduceDamageTaken15 = 510, // 0x000001FE
+        ReduceDamageTaken25 = 511, // 0x000001FF
+        CrabShell = 520, // 0x00000208
+        CritShield25 = 530, // 0x00000212
+        CritShield50 = 531, // 0x00000213
+        CritShield75 = 532, // 0x00000214
+        CritShield100 = 533, // 0x00000215
+        SkyWrath = 540, // 0x0000021C
+        Enrage = 550, // 0x00000226
+        BlockPassiveSkills = 560, // 0x00000230
+        StatusBanish = 570, // 0x0000023A
+        VoidAbyss = 580, // 0x00000244
+    }
+
+    public enum EffectKindGroup
+    {
+        Undefined = 1,
+        StatusDebuff = 2,
+        ResistibleInstantDebuff = 3,
+        EffectThatApplyStatusDebuffs = 4,
+    }
+
+    public enum LifetimeUpdateType
+    {
+        OnStartTurn,
+        OnEndTurn,
+        Custom,
+    }
+
+    public enum ApplyMode
+    {
+        Unresistable,
+        Guaranteed,
+    }
+
+    public enum ProtectionMode
+    {
+        ProtectedFromEnemies,
+        FullyProtected,
+    }
+
+    public enum UnapplyEffectTarget
+    {
+        Target = 1,
+        Producer = 2,
+    }
+
+    public enum UnapplyEffectMode
+    {
+        Selected,
+        AllExceptSelected,
+    }
+
+    public enum HitType
+    {
+        Normal,
+        Crushing,
+        Critical,
+        Glancing,
+    }
+
+    public enum ElementRelation
+    {
+        Disadvantage = -1, // 0xFFFFFFFF
+        Neutral = 0,
+        Advantage = 1,
+    }
+
+    public enum EvenMode
+    {
+        Average,
+        Highest,
+        Lowest,
+    }
+
+    public enum StatKindId
+    {
+        Health = 1,
+        Attack = 2,
+        Defence = 3,
+        Speed = 4,
+        Resistance = 5,
+        Accuracy = 6,
+        CriticalChance = 7,
+        CriticalDamage = 8,
+        CriticalHeal = 9,
+    }
+
+    public enum ActivateSkillOwner
+    {
+        Producer,
+        Target,
+    }
+
+    public enum SkillToChange
+    {
+        Random = 1,
+        ByIndex = 2,
+        SkillOfCurrentContext = 3,
+        All = 4,
+    }
+
+    public enum AppliedEffectType
+    {
+        Buff,
+        Debuff,
+    }
+
+    public enum CrabShellLayerType
+    {
+        First,
+        Second,
+        Third,
+    }
+
+    public enum PassiveBonus
+    {
+        Heal = 1,
+        ShieldCreation = 2,
+        StaminaRecovery = 3,
+        ArtifactSetStats = 4,
+    }
+
+    public class EffectRelationStub
+    {
+        [JsonProperty("eEffectTypeId")]
+        public int EffectTypeId;
+
+        [JsonProperty("effectKindIds")]
+        public IEnumerable<EffectKindId> EffectKindIds;
+
+        [JsonProperty("effectKindGroups")]
+        public IEnumerable<EffectKindGroup> EffectKindGroups;
+
+        [JsonProperty("phase")]
+        public string Phase;
+
+        [JsonProperty("activateOnGlancingHit")]
+        public bool ActivateOnGlancingHit;
+    }
+
+    public class StatusEffectParamsStub
+    {
+        [JsonProperty("strengthInFamily")]
+        public int StrengthInFamily;
+
+        [JsonProperty("forcedTickAllowed")]
+        public bool ForcedTickAllowed;
+
+        [JsonProperty("lifetimeUpdateType")]
+        public LifetimeUpdateType LifetimeUpdateType;
+
+        [JsonProperty("unapplyWhenProducerDied")]
+        public bool UnapplyWhenProducerDied;
+    }
+
+    public class StatusEffectInfoStub
+    {
+        [JsonProperty("typeId")]
+        public int TypeId;
+
+        [JsonProperty("duration")]
+        public int Duration;
+
+        [JsonProperty("ignoreEffectsLimit")]
+        public bool IgnoreEffectsLimit;
+
+        [JsonProperty("applyMode")]
+        public ApplyMode ApplyMode;
+
+        [JsonProperty("protection")]
+        public ProtectionMode Protection;
+    }
+
+    public class ApplyStatusEffectParamsStub
+    {
+        [JsonProperty("statusEffectInfos")]
+        public IEnumerable<StatusEffectInfoStub> StatusEffectInfos;
+    }
+
+    public class UnapplyStatusEffectParamsStub
+    {
+        [JsonProperty("count")]
+        public int Count;
+
+        [JsonProperty("statusEffectTypeIds")]
+        public IEnumerable<StatusEffectTypeId> StatusEffectTypeIds;
+
+        [JsonProperty("unapplyMode")]
+        public UnapplyEffectMode UnapplyMode;
+
+        [JsonProperty("removeFrom")]
+        public UnapplyEffectTarget RemoveFrom;
+
+        [JsonProperty("applyTo")]
+        public UnapplyEffectTarget ApplyTo;
+    }
+
+    public class TransferDebuffParamsStub
+    {
+        [JsonProperty("count")]
+        public int Count;
+
+        [JsonProperty("statusEffectTypeIds")]
+        public IEnumerable<StatusEffectTypeId> StatusEffectTypeIds;
+
+        [JsonProperty("unapplyMode")]
+        public UnapplyEffectMode UnapplyMode;
+
+        [JsonProperty("includeProducer")]
+        public bool IncludeProducer;
+
+        [JsonProperty("applyMode")]
+        public ApplyMode ApplyMode;
+
+        [JsonProperty("removeFrom")]
+        public EffectTargetType RemoveFrom;
+
+        [JsonProperty("applyTo")]
+        public EffectTargetType ApplyTo;
+    }
+
+    public class DamageParamsStub
+    {
+        [JsonProperty("hitType")]
+        public HitType HitType;
+
+        [JsonProperty("elementRelation")]
+        public ElementRelation ElementRelation;
+
+        [JsonProperty("defenceModifier")]
+        public long DefenceModifier;
+
+        [JsonProperty("isFixed")]
+        public bool IsFixed;
+
+        [JsonProperty("doesNotCountAsHit")]
+        public bool DoesNotCountAsHit;
+
+        [JsonProperty("increaseCriticalHitChance")]
+        public long IncreaseCriticalHitChance;
+
+        [JsonProperty("valueCapExpression")]
+        public string ValueCapExpression;
+    }
+
+    public class HealParamsStub
+    {
+        [JsonProperty("canBeCritical")]
+        public bool CanBeCritical;
+    }
+
+    public class EvenParamsStub
+    {
+        [JsonProperty("evenMode")]
+        public EvenMode EvenMode;
+    }
+
+    public class ChangeStatParamsStub
+    {
+        [JsonProperty("statKindId")]
+        public StatKindId Param;
+    }
+
+    public class ActivateSkillParamsStub
+    {
+        [JsonProperty("skillIndex")]
+        public int SkillIndex;
+
+        [JsonProperty("skillOwner")]
+        public ActivateSkillOwner SkillOwner;
+
+        [JsonProperty("targetExpression")]
+        public string TargetExpression;
+    }
+
+    public class ShowHiddenSkillParamsStub
+    {
+        [JsonProperty("skillTypeId")]
+        public int SkillTypeId;
+
+        [JsonProperty("shouldHide")]
+        public bool ShouldHide;
+    }
+
+    public class ChangeSkillCooldownParamsStub
+    {
+        [JsonProperty("turns")]
+        public int Turns;
+
+        [JsonProperty("skillIndex")]
+        public int SkillIndex;
+
+        [JsonProperty("isRandomSkill")]
+        public bool IsRandomSkill;
+
+        [JsonProperty("skillToChange")]
+        public SkillToChange SkillToChange;
+    }
+
+    public class ChangeEffectLifetimeParamsStub
+    {
+        [JsonProperty("type")]
+        public AppliedEffectType Type;
+
+        [JsonProperty("turns")]
+        public int Turns;
+
+        [JsonProperty("count")]
+        public int Count;
+
+        [JsonProperty("effectTypeIds")]
+        public IEnumerable<StatusEffectTypeId> EffectTypeIds;
+    }
+
+    public class ShareDamageParamsStub
+    {
+        [JsonProperty("targetDamageCutPerc")]
+        public long TargetDamageCutPerc;
+
+        [JsonProperty("transferedDamagePerc")]
+        public long TransferedDamagePerc;
+
+        [JsonProperty("defenceModifier")]
+        public long DefenceModifier;
+    }
+
+    public class BlockEffectParamsStub
+    {
+        [JsonProperty("effectTypeIds")]
+        public IEnumerable<int> EffectTypeIds;
+
+        [JsonProperty("effectKindIds")]
+        public IEnumerable<int> EffectKindIds;
+
+        [JsonProperty("blockGuaranteed")]
+        public bool BlockGuaranteed;
+    }
+
+    public class TeamAttackParamsStub
+    {
+        public int TeammatesCount;
+
+        public bool ExcludeProducerFromAttack;
+
+        public IEnumerable<int> PreferredHeroTypes;
+
+        public bool AlwaysUsePreferredWhenPossible;
+
+        public string AllySelectorExpression;
+    }
+
+    public class SummonParamsStub
+    {
+        [JsonProperty("baseTypeId")]
+        public int BaseTypeId;
+
+        [JsonProperty("ascendLevelFormula")]
+        public string AscendLevelFormula;
+
+        [JsonProperty("gradeFormula")]
+        public string GradeFormula;
+
+        [JsonProperty("levelFormula")]
+        public string LevelFormula;
+
+        [JsonProperty("removeAfterDeath")]
+        public bool RemoveAfterDeath;
+
+        [JsonProperty("slotsLimit")]
+        public int SlotsLimit;
+    }
+
+    public class DestroyHpParamsStub
+    {
+        [JsonProperty("ignoreShield")]
+        public bool IgnoreShield;
+    }
+
+    public class ReviveParamsStub
+    {
+        [JsonProperty("healPercent")]
+        public long HealPercent;
+
+        [JsonProperty("ignoreBlockRevive")]
+        public bool IgnoreBlockRevive;
+    }
+
+    public class CounterattackParamsStub
+    {
+        [JsonProperty("skillIndex")]
+        public int SkillIndex;
+
+        [JsonProperty("noPenalty")]
+        public bool NoPenalty;
+    }
+
+    public class ForceStatusEffectTickParamsStub
+    {
+        [JsonProperty("ticks")]
+        public int Ticks;
+
+        [JsonProperty("effectTypeIds")]
+        public IEnumerable<StatusEffectTypeId> EffectTypeIds;
+
+        [JsonProperty("effectCount")]
+        public int EffectCount;
+    }
+
+    public class CrabShellLayerStub
+    {
+        [JsonProperty("type")]
+        public CrabShellLayerType Type;
+
+        [JsonProperty("multiplierFormula")]
+        public string MultiplierFormula;
+
+        [JsonProperty("conditionFormula")]
+        public string ConditionFormula;
+    }
+
+    public class CrabShellParamsStub
+    {
+        [JsonProperty("layers")]
+        public IEnumerable<CrabShellLayerStub> Layers;
+    }
+
+    public class ReturnDebuffsParamsStub
+    {
+        [JsonProperty("applyMode")]
+        public ApplyMode ApplyMode;
+    }
+
+    public class HitTypeParamsStub
+    {
+        [JsonProperty("hitTypeToChange")]
+        public HitType HitTypeToChange;
+
+        [JsonProperty("hitType")]
+        public HitType HitType;
+    }
+
+    public class PassiveBonusParamsStub
+    {
+        [JsonProperty("bonus")]
+        public PassiveBonus Bonus;
+    }
+
+    public class MultiplyStatusEffectParamsStub
+    {
+        [JsonProperty("count")]
+        public int Count;
+
+        [JsonProperty("turnsModifier")]
+        public int TurnsModifier;
+
+        [JsonProperty("effectKindIds")]
+        public IEnumerable<EffectKindId> EffectKindIds;
+
+        [JsonProperty("targetSelectorExpression")]
+        public string TargetSelectorExpression;
+    }
+
+    public class IgnoreProtectionEffectsParamsStub
+    {
+        [JsonProperty("ignoreBlockDamage")]
+        public bool IgnoreBlockDamage;
+
+        [JsonProperty("ignoreShield")]
+        public bool IgnoreShield;
+
+        [JsonProperty("ignoreUnkillable")]
+        public bool IgnoreUnkillable;
+    }
+
+    public class ChangeEffectTargetParamsStub
+    {
+        [JsonProperty("overrideApplyMode")]
+        public bool OverrideApplyMode;
+
+        [JsonProperty("applyMode")]
+        public ApplyMode ApplyMode;
+    }
+
+
+    //public class EffectContainerParamsStub
+    //{
+    //    [JsonProperty("effect")]
+    //    public EffectType Effect;
+    //}
+
     public class EffectType
     {
         [JsonProperty("id")]
@@ -91,6 +799,159 @@ namespace Raid.DataModel
         public string KindId;
 
         // TODO: there's a lot more data here we could extract
+
+        [JsonProperty("isActive")]
+        public bool IsActive;
+
+        [JsonProperty("targetType")]
+        public string TargetType;
+
+        [JsonProperty("targetExclusion")]
+        public string TargetExclusion;
+
+        [JsonProperty("isTargetExclusive")]
+        public bool IsTargetExclusive;
+
+        [JsonProperty("isTargetFirstHitInSelected")]
+        public bool IsTargetFirstHitInSelected;
+
+        [JsonProperty("targetCondition")]
+        public string TargetCondition;
+
+        [JsonProperty("isEffectDescription")]
+        public bool IsEffectDescription;
+
+        [JsonProperty("considersDead")]
+        public bool ConsidersDead;
+
+        [JsonProperty("leaveThroughDeath")]
+        public bool LeaveThroughDeath;
+
+        [JsonProperty("doesntSetSkillOnCooldown")]
+        public bool DoesntSetSkillOnCooldown;
+
+        [JsonProperty("ignoresCooldown")]
+        public bool IgnoresCooldown;
+
+        [JsonProperty("isUnique")]
+        public bool IsUnique;
+
+        [JsonProperty("iterationChanceRolling")]
+        public bool IterationChanceRolling;
+
+        [JsonProperty("relation")]
+        public EffectRelationStub Relation;
+
+        [JsonProperty("condition")]
+        public string Condition;
+
+        [JsonProperty("chance")]
+        public long Chance;
+
+        [JsonProperty("repeatChance")]
+        public long RepeatChance;
+
+        [JsonProperty("statusEffectParams")]
+        public StatusEffectParamsStub StatusParams;
+
+        [JsonProperty("valueCap")]
+        public string ValueCap;
+
+        [JsonProperty("applyInstantEffectMode")]
+        public ApplyMode ApplyInstantEffectMode;
+
+        [JsonProperty("persistsThroughRounds")]
+        public bool PersistsThroughRounds;
+
+        [JsonProperty("snapshotRequired")]
+        public bool SnapshotRequired;
+
+        [JsonProperty("ignoredEffects")]
+        public IEnumerable<EffectKindId> IgnoredEffects;
+
+        [JsonProperty("applyStatusEffectParams")]
+        public ApplyStatusEffectParamsStub ApplyStatusEffectParams;
+
+        [JsonProperty("unapplyStatusEffectParams")]
+        public UnapplyStatusEffectParamsStub UnapplyStatusEffectParams;
+
+        [JsonProperty("transferDebuffParams")]
+        public TransferDebuffParamsStub TransferDebuffParams;
+
+        [JsonProperty("damageParams")]
+        public DamageParamsStub DamageParams;
+
+        [JsonProperty("healParams")]
+        public HealParamsStub HealParams;
+
+        [JsonProperty("evenParams")]
+        public EvenParamsStub EvenParams;
+
+        [JsonProperty("changeStatParams")]
+        public ChangeStatParamsStub ChangeStatParams;
+
+        [JsonProperty("activateSkillParams")]
+        public ActivateSkillParamsStub ActivateSkillParams;
+
+        [JsonProperty("showHiddenSkillParams")]
+        public ShowHiddenSkillParamsStub ShowHiddenSkillParams;
+
+        [JsonProperty("changeSkillCooldownParams")]
+        public ChangeSkillCooldownParamsStub ChangeSkillCooldownParams;
+
+        [JsonProperty("changeEffectLifetimeParams")]
+        public ChangeEffectLifetimeParamsStub ChangeEffectLifetimeParams;
+
+        [JsonProperty("shareDamageParams")]
+        public ShareDamageParamsStub ShareDamageParams;
+
+        [JsonProperty("blockEffectParams")]
+        public BlockEffectParamsStub BlockEffectParams;
+
+        [JsonProperty("summonParams")]
+        public SummonParamsStub SummonParams;
+
+        [JsonProperty("teamAttackParams")]
+        public TeamAttackParamsStub TeamAttackParams;
+
+        [JsonProperty("destroyHpParams")]
+        public DestroyHpParamsStub DestroyHpParams;
+
+        [JsonProperty("reviveParams")]
+        public ReviveParamsStub ReviveParams;
+
+        [JsonProperty("counterattackParams")]
+        public CounterattackParamsStub CounterattackParams;
+
+        [JsonProperty("forceTickParams")]
+        public ForceStatusEffectTickParamsStub ForceTickParams;
+
+        [JsonProperty("crabShellParams")]
+        public CrabShellParamsStub CrabShellParams;
+
+        [JsonProperty("returnDebuffsParams")]
+        public ReturnDebuffsParamsStub ReturnDebuffsParams;
+
+        [JsonProperty("hitTypeParams")]
+        public HitTypeParamsStub HitTypeParams;
+
+        [JsonProperty("passiveBonusParams")]
+        public PassiveBonusParamsStub PassiveBonusParams;
+
+        [JsonProperty("multiplyStatusEffectParams")]
+        public MultiplyStatusEffectParamsStub MultiplyStatusEffectParams;
+
+        [JsonProperty("ignoreProtectionEffectsParams")]
+        public IgnoreProtectionEffectsParamsStub IgnoreProtectionEffectsParams;
+
+        [JsonProperty("changeEffectTargetParams")]
+        public ChangeEffectTargetParamsStub ChangeEffectTargetParams;
+
+        //[JsonProperty("effectContainerParams")]
+        //public EffectContainerParamsStub EffectContainerParams;
+
+        [JsonProperty("multiplierDependsOnRelation")]
+        public bool MultiplierDependsOnRelation;
     }
 
     public class SkillUpgrade

--- a/SDK/DataModel/StaticData/SkillType.cs
+++ b/SDK/DataModel/StaticData/SkillType.cs
@@ -74,6 +74,12 @@ namespace Raid.DataModel
         }
     }
 
+    public enum EffectGroup
+    {
+        Active,
+        Passive,
+    }
+
     public enum EffectKindId
     {
         Revive = 0,
@@ -222,6 +228,14 @@ namespace Raid.DataModel
         EnemyWithLowestStamina = 38, // 0x00000026
         EnemyWithHighestStamina = 39, // 0x00000027
         RelationProducerOrTeamAttackInitiator = 40, // 0x00000028
+    }
+
+    public enum TargetExclusion
+    {
+        Target,
+        Producer,
+        RelationTarget,
+        RelationProducer,
     }
 
     public enum StatusEffectTypeId
@@ -411,6 +425,27 @@ namespace Raid.DataModel
         ShieldCreation = 2,
         StaminaRecovery = 3,
         ArtifactSetStats = 4,
+    }
+
+    public class EffectGroupStub
+    {}
+
+    public class TargetParamsStub
+    {
+        [JsonProperty("targetType")]
+        public EffectTargetType TargetType;
+
+        [JsonProperty("exclusion")]
+        public TargetExclusion Exclusion;
+
+        [JsonProperty("exclusive")]
+        public bool Exclusive;
+
+        [JsonProperty("firstHitInSelected")]
+        public bool FirstHitInSelected;
+
+        [JsonProperty("condition")]
+        public string Condition;
     }
 
     public class EffectRelationStub
@@ -774,13 +809,6 @@ namespace Raid.DataModel
         public ApplyMode ApplyMode;
     }
 
-
-    //public class EffectContainerParamsStub
-    //{
-    //    [JsonProperty("effect")]
-    //    public EffectType Effect;
-    //}
-
     public class EffectType
     {
         [JsonProperty("id")]
@@ -800,23 +828,11 @@ namespace Raid.DataModel
 
         // TODO: there's a lot more data here we could extract
 
-        [JsonProperty("isActive")]
-        public bool IsActive;
+        [JsonProperty("group")]
+        public EffectGroup Group;
 
-        [JsonProperty("targetType")]
-        public string TargetType;
-
-        [JsonProperty("targetExclusion")]
-        public string TargetExclusion;
-
-        [JsonProperty("isTargetExclusive")]
-        public bool IsTargetExclusive;
-
-        [JsonProperty("isTargetFirstHitInSelected")]
-        public bool IsTargetFirstHitInSelected;
-
-        [JsonProperty("targetCondition")]
-        public string TargetCondition;
+        [JsonProperty("targetParams")]
+        public TargetParamsStub TargetParams;
 
         [JsonProperty("isEffectDescription")]
         public bool IsEffectDescription;
@@ -946,9 +962,6 @@ namespace Raid.DataModel
 
         [JsonProperty("changeEffectTargetParams")]
         public ChangeEffectTargetParamsStub ChangeEffectTargetParams;
-
-        //[JsonProperty("effectContainerParams")]
-        //public EffectContainerParamsStub EffectContainerParams;
 
         [JsonProperty("multiplierDependsOnRelation")]
         public bool MultiplierDependsOnRelation;

--- a/SDK/Service/DataModel/HeroStatsCalculator.cs
+++ b/SDK/Service/DataModel/HeroStatsCalculator.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Raid.DataModel;
-using SharedModel.Battle.Effects;
 using System;
+using StatKindId = SharedModel.Battle.Effects.StatKindId;
 
 namespace Raid.Service
 {

--- a/SDK/Service/Facets/ArenaFacet.cs
+++ b/SDK/Service/Facets/ArenaFacet.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Raid.DataModel;
-using SharedModel.Battle.Effects;
+using StatKindId = SharedModel.Battle.Effects.StatKindId;
 
 namespace Raid.Service
 {

--- a/SDK/Service/Facets/StaticData/StaticDataFacet.cs
+++ b/SDK/Service/Facets/StaticData/StaticDataFacet.cs
@@ -24,7 +24,10 @@ namespace Raid.Service
                 kvp => (DataModel.Enums.HeroRarity)kvp.Key,
                 kvp => kvp.Value.Select(bonuses => bonuses.Bonuses.Select(bonus => bonus.Value.ToModel(bonus.Key)).ToArray()).ToArray()
             );
-            var localizedStrings = new Dictionary<string, string>(staticData.ClientLocalization.Concat(staticData.StaticDataLocalization));
+            var localizedStrings = new Dictionary<string, string>(staticData.ClientLocalization
+                .Concat(staticData.StaticDataLocalization)
+                .GroupBy(x => x.Key)
+                .Select(g => g.First()));
 
             var areas = new Dictionary<AreaTypeId, AreaData>();
             var regions = new Dictionary<RegionTypeId, RegionData>();

--- a/SDK/Service/Runtime/ModelExtensions.cs
+++ b/SDK/Service/Runtime/ModelExtensions.cs
@@ -315,6 +315,331 @@ namespace Raid.DataModel
             };
         }
 
+        public static EffectRelationStub ToModel(this SharedModel.Battle.Effects.EffectRelation type)
+        {
+            return new EffectRelationStub
+            {
+                EffectTypeId = type.EffectTypeId.Value,
+                EffectKindIds = type.EffectKindIds?.Cast<EffectKindId>(),
+                EffectKindGroups = type.EffectKindGroups?.Cast<EffectKindGroup>(),
+                Phase = type.Phase.ToString(),
+                ActivateOnGlancingHit = type.ActivateOnGlancingHit
+            };
+        }
+
+        public static StatusEffectParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.StatusEffectParams.StatusEffectParams type)
+        {
+            return new StatusEffectParamsStub
+            {
+                StrengthInFamily = type.StrengthInFamily,
+                ForcedTickAllowed = type.ForcedTickAllowed,
+                LifetimeUpdateType = (LifetimeUpdateType)type.LifetimeUpdateType,
+                UnapplyWhenProducerDied = type.UnapplyWhenProducerDied.Value,
+            };
+        }
+
+        public static ApplyStatusEffectParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.ApplyStatusEffectParams type)
+        {
+            var stub = new ApplyStatusEffectParamsStub { StatusEffectInfos = new List<StatusEffectInfoStub>() };
+            foreach (var x in type.StatusEffectInfos)
+            {
+                stub.StatusEffectInfos.Append(new StatusEffectInfoStub
+                {
+                    TypeId = x.TypeId,
+                    Duration = x.Duration,
+                    IgnoreEffectsLimit = x.IgnoreEffectsLimit,
+                    ApplyMode = (ApplyMode)x.ApplyMode.Value,
+                    Protection = (ProtectionMode)x.Protection.Value
+                });
+            }
+            return stub;
+        }
+
+        public static UnapplyStatusEffectParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.UnapplyStatusEffectParams type)
+        {
+            return new UnapplyStatusEffectParamsStub
+            {
+                Count = type.Count,
+                StatusEffectTypeIds = type.StatusEffectTypeIds?.Cast<StatusEffectTypeId>(),
+                UnapplyMode = (UnapplyEffectMode)type.UnapplyMode,
+                RemoveFrom = (UnapplyEffectTarget)type.RemoveFrom.Value,
+                ApplyTo = (UnapplyEffectTarget)type.ApplyTo.Value,
+            };
+        }
+
+        public static TransferDebuffParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.TransferDebuffParams type)
+        {
+            return new TransferDebuffParamsStub
+            {
+                Count = type.Count,
+                StatusEffectTypeIds = type.StatusEffectTypeIds?.Cast<StatusEffectTypeId>(),
+                UnapplyMode = (UnapplyEffectMode)type.UnapplyMode,
+                IncludeProducer = type.IncludeProducer,
+                ApplyMode = (ApplyMode)type.ApplyMode.Value,
+                RemoveFrom = (EffectTargetType)type.RemoveFrom,
+                ApplyTo = (EffectTargetType)type.ApplyTo,
+            };
+        }
+
+        public static DamageParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.DamageParams type)
+        {
+            return new DamageParamsStub
+            {
+                HitType = (HitType)type.HitType.Value,
+                ElementRelation = (ElementRelation)type.ElementRelation.Value,
+                DefenceModifier = type.DefenceModifier.m_rawValue,
+                IsFixed = type.IsFixed,
+                DoesNotCountAsHit = type.DoesNotCountAsHit,
+                IncreaseCriticalHitChance = type.IncreaseCriticalHitChance.Value.m_rawValue,
+                ValueCapExpression = type.ValueCapExpression,
+            };
+        }
+
+        public static HealParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.HealParams type)
+        {
+            return new HealParamsStub
+            {
+                CanBeCritical = type.CanBeCritical,
+            };
+        }
+
+        public static EvenParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.EvenParams type)
+        {
+            return new EvenParamsStub
+            {
+                EvenMode = (EvenMode)type.EvenMode,
+            };
+        }
+
+        public static ChangeStatParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.ChangeStatParams type)
+        {
+            return new ChangeStatParamsStub
+            {
+                Param = (StatKindId)type.Param,
+            };
+        }
+
+        public static ActivateSkillParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.ActivateSkillParams.ActivateSkillParams type)
+        {
+            return new ActivateSkillParamsStub
+            {
+                SkillIndex = type.SkillIndex,
+                SkillOwner = (ActivateSkillOwner)type.SkillOwner,
+                TargetExpression = type.TargetExpression,
+            };
+        }
+
+        public static ShowHiddenSkillParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.ShowHiddenSkillParams type)
+        {
+            return new ShowHiddenSkillParamsStub
+            {
+                SkillTypeId = type.SkillTypeId,
+                ShouldHide = type.ShouldHide,
+            };
+        }
+
+        public static ChangeSkillCooldownParamsStub ToModel(
+            this SharedModel.Battle.Effects.EffectParams.ChangeSkillCooldownParams type)
+        {
+            return new ChangeSkillCooldownParamsStub
+            {
+                Turns = type.Turns,
+                SkillIndex = type.SkillIndex.Value,
+                IsRandomSkill = type.IsRandomSkill.Value,
+                SkillToChange = (SkillToChange)type.SkillToChange,
+            };
+        }
+
+        public static ChangeEffectLifetimeParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.ChangeEffectLifetimeParams type)
+        {
+            return new ChangeEffectLifetimeParamsStub
+            {
+                Type = (AppliedEffectType)type.Type,
+                Turns = type.Turns,
+                Count = type.Count,
+                EffectTypeIds = type.EffectTypeIds?.Cast<StatusEffectTypeId>(),
+            };
+        }
+
+        public static ShareDamageParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.ShareDamageParams type)
+        {
+            return new ShareDamageParamsStub
+            {
+                TargetDamageCutPerc = type.TargetDamageCutPerc.m_rawValue,
+                TransferedDamagePerc = type.TransferedDamagePerc.m_rawValue,
+                DefenceModifier = type.DefenceModifier.Value.m_rawValue,
+            };
+        }
+
+        public static BlockEffectParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.BlockEffectParams type)
+        {
+            return new BlockEffectParamsStub
+            {
+                EffectTypeIds = type.EffectTypeIds?.Cast<int>(),
+                EffectKindIds = type.EffectKindIds?.Cast<int>(),
+                BlockGuaranteed = type.BlockGuaranteed.Value,
+            };
+        }
+
+        public static SummonParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.SummonParams type)
+        {
+            return new SummonParamsStub
+            {
+                BaseTypeId = type.BaseTypeId,
+                AscendLevelFormula = type.AscendLevelFormula,
+                GradeFormula = type.GradeFormula,
+                LevelFormula = type.LevelFormula,
+                RemoveAfterDeath = type.RemoveAfterDeath,
+                SlotsLimit = type.SlotsLimit,
+            };
+        }
+
+        public static TeamAttackParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.TeamAttackParams type)
+        {
+            return new TeamAttackParamsStub
+            {
+                TeammatesCount = type.TeammatesCount,
+                ExcludeProducerFromAttack = type.ExcludeProducerFromAttack,
+                PreferredHeroTypes = type.PreferredHeroTypes,
+                AlwaysUsePreferredWhenPossible = type.AlwaysUsePreferredWhenPossible.Value,
+                AllySelectorExpression = type.AllySelectorExpression,
+            };
+        }
+
+        public static DestroyHpParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.DestroyHpParams type)
+        {
+            return new DestroyHpParamsStub
+            {
+                IgnoreShield = type.IgnoreShield,
+            };
+        }
+
+        public static ReviveParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.ReviveParams type)
+        {
+            return new ReviveParamsStub
+            {
+                HealPercent = type.HealPercent.m_rawValue,
+                IgnoreBlockRevive = type.IgnoreBlockRevive,
+            };
+        }
+
+        public static CounterattackParamsStub ToModel(
+            this SharedModel.Battle.Effects.EffectParams.CounterattackParams type)
+        {
+            return new CounterattackParamsStub
+            {
+                SkillIndex = type.SkillIndex,
+                NoPenalty = type.NoPenalty,
+            };
+        }
+
+        public static ForceStatusEffectTickParamsStub ToModel(
+            this SharedModel.Battle.Effects.EffectParams.ForceStatusEffectTickParams type)
+        {
+            return new ForceStatusEffectTickParamsStub
+            {
+                Ticks = type.Ticks,
+                EffectTypeIds = type.EffectTypeIds?.Cast<StatusEffectTypeId>(),
+                EffectCount = type.EffectCount,
+            };
+        }
+
+        public static CrabShellLayerStub ToModel(
+            this SharedModel.Battle.Effects.EffectParams.CrabShellParams.CrabShellLayer type)
+        {
+            return new CrabShellLayerStub
+            {
+                Type = (CrabShellLayerType)type.Type,
+                MultiplierFormula = type.MultiplierFormula,
+                ConditionFormula = type.ConditionFormula,
+            };
+        }
+
+        public static IEnumerable<CrabShellLayerStub> ToModel(
+            this IEnumerable<SharedModel.Battle.Effects.EffectParams.CrabShellParams.CrabShellLayer> type)
+        {
+            return type.Select(ToModel);
+        }
+
+        public static CrabShellParamsStub ToModel(
+            this SharedModel.Battle.Effects.EffectParams.CrabShellParams.CrabShellParams type)
+        {
+            return new CrabShellParamsStub
+            {
+                Layers = type.Layers.ToModel(),
+            };
+        }
+
+        public static ReturnDebuffsParamsStub ToModel(
+            this SharedModel.Battle.Effects.EffectParams.ReturnDebuffsParams type)
+        {
+            return new ReturnDebuffsParamsStub
+            {
+                ApplyMode = (ApplyMode)type.ApplyMode.Value,
+            };
+        }
+
+        public static HitTypeParamsStub ToModel(this SharedModel.Battle.Effects.EffectParams.HitTypeParams type)
+        {
+            return new HitTypeParamsStub
+            {
+                HitTypeToChange = (HitType)type.HitTypeToChange.Value,
+                HitType = (HitType)type.HitType,
+            };
+        }
+
+        public static PassiveBonusParamsStub ToModel(
+            this SharedModel.Battle.Effects.EffectParams.PassiveBonusParams type)
+        {
+            return new PassiveBonusParamsStub
+            {
+                Bonus = (PassiveBonus)type.Bonus,
+            };
+        }
+
+        public static MultiplyStatusEffectParamsStub ToModel(
+            this SharedModel.Battle.Effects.EffectParams.MultiplyStatusEffectParams type)
+        {
+            return new MultiplyStatusEffectParamsStub
+            {
+                Count = type.Count,
+                TurnsModifier = type.TurnsModifier,
+                EffectKindIds = type.EffectKindIds?.Cast<EffectKindId>(),
+                TargetSelectorExpression = type.TargetSelectorExpression,
+            };
+        }
+
+        public static IgnoreProtectionEffectsParamsStub ToModel(
+            this SharedModel.Battle.Effects.EffectParams.IgnoreProtectionEffectsParams type)
+        {
+            return new IgnoreProtectionEffectsParamsStub
+            {
+                IgnoreBlockDamage = type.IgnoreBlockDamage,
+                IgnoreShield = type.IgnoreShield,
+                IgnoreUnkillable = type.IgnoreUnkillable,
+            };
+        }
+
+
+        public static ChangeEffectTargetParamsStub ToModel(
+            this SharedModel.Battle.Effects.EffectParams.ChangeEffectTargetParams type)
+        {
+            return new ChangeEffectTargetParamsStub
+            {
+                OverrideApplyMode = type.OverrideApplyMode,
+                ApplyMode = (ApplyMode)type.ApplyMode.Value,
+            };
+        }
+
+        //public static EffectContainerParamsStub ToModel(
+        //    this SharedModel.Battle.Effects.EffectParams.EffectContainerParams type)
+        //{
+        //    return new EffectContainerParamsStub
+        //    {
+        //        Effect = (EffectType)type.Effect,
+        //    };
+        //}
+
         public static EffectType ToModel(this SharedModel.Battle.Effects.EffectType type)
         {
             return new EffectType()
@@ -324,6 +649,60 @@ namespace Raid.DataModel
                 Count = type.Count,
                 StackCount = type.StackCount,
                 Multiplier = type.MultiplierFormula,
+
+                IsActive = type.Group == SharedModel.Battle.Effects.EffectGroup.Active,
+
+                TargetType = type.TargetParams.TargetType.ToString(),
+                TargetExclusion = type.TargetParams.Exclusion.ToString(),
+                IsTargetExclusive = type.TargetParams.Exclusive,
+                IsTargetFirstHitInSelected = type.TargetParams.FirstHitInSelected,
+                TargetCondition = type.TargetParams.Condition,
+
+                IsEffectDescription = type.IsEffectDescription,
+                ConsidersDead = type.ConsidersDead,
+                LeaveThroughDeath = type.LeaveThroughDeath,
+                DoesntSetSkillOnCooldown = type.DoesntSetSkillOnCooldown,
+                IgnoresCooldown = type.IgnoresCooldown,
+                IsUnique = type.IsUnique,
+                IterationChanceRolling = type.IterationChanceRolling,
+                Relation = type.Relation?.ToModel(),
+                Condition = type.Condition,
+                Chance = type.Chance.Value.m_rawValue,
+                RepeatChance = type.RepeatChance.Value.m_rawValue,
+                StatusParams = type.StatusParams?.ToModel(),
+                ValueCap = type.ValueCap,
+                ApplyInstantEffectMode = (ApplyMode)type.ApplyInstantEffectMode.Value,
+                PersistsThroughRounds = type.PersistsThroughRounds,
+                SnapshotRequired = type.SnapshotRequired,
+                IgnoredEffects = type.IgnoredEffects?.Cast<EffectKindId>(),
+                ApplyStatusEffectParams = type.ApplyStatusEffectParams?.ToModel(),
+                UnapplyStatusEffectParams = type.UnapplyStatusEffectParams?.ToModel(),
+                TransferDebuffParams = type.TransferDebuffParams?.ToModel(),
+                DamageParams = type.DamageParams?.ToModel(),
+                HealParams = type.HealParams?.ToModel(),
+                EvenParams = type.EvenParams?.ToModel(),
+                ChangeStatParams = type.ChangeStatParams?.ToModel(),
+                ActivateSkillParams = type.ActivateSkillParams?.ToModel(),
+                ShowHiddenSkillParams = type.ShowHiddenSkillParams?.ToModel(),
+                ChangeSkillCooldownParams = type.ChangeSkillCooldownParams?.ToModel(),
+                ChangeEffectLifetimeParams = type.ChangeEffectLifetimeParams?.ToModel(),
+                ShareDamageParams = type.ShareDamageParams?.ToModel(),
+                BlockEffectParams = type.BlockEffectParams?.ToModel(),
+                SummonParams = type.SummonParams?.ToModel(),
+                TeamAttackParams = type.TeamAttackParams?.ToModel(),
+                DestroyHpParams = type.DestroyHpParams?.ToModel(),
+                ReviveParams = type.ReviveParams?.ToModel(),
+                CounterattackParams = type.CounterattackParams?.ToModel(),
+                ForceTickParams = type.ForceTickParams?.ToModel(),
+                CrabShellParams = type.CrabShellParams?.ToModel(),
+                ReturnDebuffsParams = type.ReturnDebuffsParams?.ToModel(),
+                HitTypeParams = type.HitTypeParams?.ToModel(),
+                PassiveBonusParams = type.PassiveBonusParams?.ToModel(),
+                MultiplyStatusEffectParams = type.MultiplyStatusEffectParams?.ToModel(),
+                IgnoreProtectionEffectsParams = type.IgnoreProtectionEffectsParams?.ToModel(),
+                ChangeEffectTargetParams = type.ChangeEffectTargetParams?.ToModel(),
+                //EffectContainerParams = type.EffectContainerParams?.ToModel(),
+                MultiplierDependsOnRelation = type.MultiplierDependsOnRelation,
             };
         }
 

--- a/SDK/Service/Runtime/ModelExtensions.cs
+++ b/SDK/Service/Runtime/ModelExtensions.cs
@@ -315,6 +315,23 @@ namespace Raid.DataModel
             };
         }
 
+        public static EffectGroup ToModel(this SharedModel.Battle.Effects.EffectGroup type)
+        {
+            return (EffectGroup)type;
+        }
+
+        public static TargetParamsStub ToModel(this SharedModel.Battle.Effects.EffectTargetParams.TargetParams type)
+        {
+            return new TargetParamsStub
+            {
+                TargetType = (EffectTargetType)type.TargetType,
+                Exclusion = (TargetExclusion)type.Exclusion.Value,
+                Exclusive = type.Exclusive,
+                FirstHitInSelected = type.FirstHitInSelected,
+                Condition = type.Condition,
+            };
+        }
+
         public static EffectRelationStub ToModel(this SharedModel.Battle.Effects.EffectRelation type)
         {
             return new EffectRelationStub
@@ -620,7 +637,6 @@ namespace Raid.DataModel
             };
         }
 
-
         public static ChangeEffectTargetParamsStub ToModel(
             this SharedModel.Battle.Effects.EffectParams.ChangeEffectTargetParams type)
         {
@@ -630,15 +646,6 @@ namespace Raid.DataModel
                 ApplyMode = (ApplyMode)type.ApplyMode.Value,
             };
         }
-
-        //public static EffectContainerParamsStub ToModel(
-        //    this SharedModel.Battle.Effects.EffectParams.EffectContainerParams type)
-        //{
-        //    return new EffectContainerParamsStub
-        //    {
-        //        Effect = (EffectType)type.Effect,
-        //    };
-        //}
 
         public static EffectType ToModel(this SharedModel.Battle.Effects.EffectType type)
         {
@@ -650,14 +657,8 @@ namespace Raid.DataModel
                 StackCount = type.StackCount,
                 Multiplier = type.MultiplierFormula,
 
-                IsActive = type.Group == SharedModel.Battle.Effects.EffectGroup.Active,
-
-                TargetType = type.TargetParams.TargetType.ToString(),
-                TargetExclusion = type.TargetParams.Exclusion.ToString(),
-                IsTargetExclusive = type.TargetParams.Exclusive,
-                IsTargetFirstHitInSelected = type.TargetParams.FirstHitInSelected,
-                TargetCondition = type.TargetParams.Condition,
-
+                Group = type.Group.ToModel(),
+                TargetParams = type.TargetParams.ToModel(),
                 IsEffectDescription = type.IsEffectDescription,
                 ConsidersDead = type.ConsidersDead,
                 LeaveThroughDeath = type.LeaveThroughDeath,
@@ -701,7 +702,6 @@ namespace Raid.DataModel
                 MultiplyStatusEffectParams = type.MultiplyStatusEffectParams?.ToModel(),
                 IgnoreProtectionEffectsParams = type.IgnoreProtectionEffectsParams?.ToModel(),
                 ChangeEffectTargetParams = type.ChangeEffectTargetParams?.ToModel(),
-                //EffectContainerParams = type.EffectContainerParams?.ToModel(),
                 MultiplierDependsOnRelation = type.MultiplierDependsOnRelation,
             };
         }


### PR DESCRIPTION
Attempt to extend the Raid.DataModel.EffectType with missed data. All properties declared in the SharedModel.Battle.Effects.EffectType have to be read now. Kindly appreciate any comments.